### PR TITLE
fix: increase default GET presigned URL expiry from 24s to 1 hour

### DIFF
--- a/modules/trishul-object-store-file-service-aws/src/main/resources/object-store-file-service-aws-application.properties
+++ b/modules/trishul-object-store-file-service-aws/src/main/resources/object-store-file-service-aws-application.properties
@@ -1,3 +1,3 @@
 # App ObjectStore
-app.object-store.file.get.url.expiry=24
+app.object-store.file.get.url.expiry=3600
 app.object-store.bucket.name=root-bucket


### PR DESCRIPTION
## Problem

The default GET presigned URL expiry is **24 seconds** (`app.object-store.file.get.url.expiry=24`). This is dangerously short for AI/LLM workflows.

### Failure chain observed in production (Wezeon)

1. Frontend uploads a prescription scan → `POST /api/v1/vfs/files` returns a PUT presigned URL
2. Image is uploaded successfully
3. Frontend calls `POST /api/v1/prescriptions/scan`
4. Backend generates a **GET presigned URL** (24s expiry) and passes it to OpenRouter → Google Gemini
5. OpenRouter/Gemini tries to download the image → **403 Forbidden** because the 24s window expired:
   ```
   "Received 403 status code when fetching image from URL:
    ...X-Amz-Expires=23"
   ```

### Fix

```diff
-app.object-store.file.get.url.expiry=24
+app.object-store.file.get.url.expiry=3600
```

Existing test `ObjectStoreFileServiceAwsAutoConfigurationTest` already uses `3600L`, so no test changes needed.